### PR TITLE
[nathan] 동전분배 0303 java 풀이 실패

### DIFF
--- a/nathan/java/src/main/java/org/example/mar/동전분배0303.java
+++ b/nathan/java/src/main/java/org/example/mar/동전분배0303.java
@@ -1,0 +1,61 @@
+package org.example.mar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class 동전분배0303 {
+
+	static List<Integer> coins = new ArrayList<>();
+	static int answer;
+
+	// 동전 c개를 선택하여 총 금액의 절반 금액을 만들어 낼 수 있다면 true 아니면 false
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 3; i++) {
+			answer = 0;
+			int n = Integer.parseInt(br.readLine());
+			int totalPrice = 0;
+			int price, nums;
+			for (int j = 0; j < n; j++) {
+				st = new StringTokenizer(br.readLine());
+				price = Integer.parseInt(st.nextToken());
+				nums = Integer.parseInt(st.nextToken());
+				for (int k = 0; k < nums; k++) {
+					coins.add(price);
+				}
+				totalPrice += price * nums;
+			}
+			totalPrice /= 2;
+			boolean[] visited = new boolean[coins.size()];
+			backtracking(0, visited, totalPrice, 0);
+			sb.append(answer).append("\n");
+		}
+		System.out.println(sb);
+	}
+
+	static void backtracking(int sum, boolean[] visited, int totalPrice, int start) {
+		if (sum >= totalPrice) {
+			if (sum == totalPrice) {
+				answer = 1;
+			}
+			return;
+		}
+
+		for (int i = start; i < coins.size(); i++) {
+			if (!visited[i]) {
+				visited[i] = true;
+				sum += coins.get(i);
+				backtracking(sum, visited, totalPrice, i+1);
+				sum -= coins.get(i);
+				visited[i] = false;
+			}
+		}
+	}
+
+}

--- a/nathan/java/src/main/java/org/example/mar/동전분배0303_2.java
+++ b/nathan/java/src/main/java/org/example/mar/동전분배0303_2.java
@@ -1,0 +1,44 @@
+package org.example.mar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class 동전분배0303_2 {
+	static List<Integer> coins = new ArrayList<>();
+	static int answer;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 3; i++) {
+			answer = 0;
+			int n = Integer.parseInt(br.readLine());
+			int totalPrice = 0;
+			int price, nums;
+			for (int j = 0; j < n; j++) {
+				st = new StringTokenizer(br.readLine());
+				price = Integer.parseInt(st.nextToken());
+				nums = Integer.parseInt(st.nextToken());
+				for (int k = 0; k < nums; k++) {
+					coins.add(price);
+				}
+				totalPrice += price * nums;
+			}
+			totalPrice /= 2;
+			boolean[] visited = new boolean[coins.size()];
+
+			sb.append(answer).append("\n");
+		}
+		System.out.println(sb);
+	}
+
+	static void dp() {
+
+	}
+
+}


### PR DESCRIPTION
<!-- 라벨을 붙여주세요 -->
<!-- 풀이 여부 : 정답 ✅, 오답 ❌, 애매모호 ⚠️ -->
<!-- 재풀이 횟수 : 1️⃣, 2️⃣, 3️⃣-->
<!-- 풀이 언어 : `python`, `java` -->

## 풀이 과정 요약 
<!-- 풀이 과정을 간략한 글로 설명해주세요 -->
- 동전 총합의 절반 금액을 채울 수 있는지 여부를 backtracking으로 체크하였습니다.
- 이렇게 되면, 동전 개수가 최대 10만개가 될 수 있는 이 문제에서는 시간 복잡도가 O(2^(동전 개수))까지 발생할 수 있게 되어 시간초과가 나옵니다.
- 추후 DP를 통해 문제를 해결해보겠습니다.

## 시간 복잡도와 공간 복잡도 기재
<!-- 복잡도를 측정하기 어렵다면 어렵다고 써주세요 -->
- 시간 복잡도 : O()
- 공간 복잡도 : O()

## 새로 찾은 풀이(혹은 좋은 풀이 방법을 찾았다면 기재)


